### PR TITLE
Bug fix for ignore-BIDS

### DIFF
--- a/bids-dni-v1.json
+++ b/bids-dni-v1.json
@@ -458,7 +458,7 @@
 						"$on": "acquisition.label",
 						"$cases": [
 							{
-								"$regex": "(^|_)ignore-BIDS",
+								"$regex": "(^|.*_)ignore-BIDS",
 								"$value": true
 							},
 							{

--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,7 @@
   "maintainer": "Jonas Kaplan <jtkaplan@usc.edu>",
   "source": "https://github.com/uscbci/dni-curate-bids",
   "url": "http://bids.neuroimaging.io/",
-  "version": "1.1",
+  "version": "1.2",
   "custom": {
     "docker-image": "flywheel/curate-bids:1.0.0_0.9.1",
     "gear-builder": {


### PR DESCRIPTION
This bug was fixed in Flywheel's curate-bids gear a while ago (https://gitlab.com/flywheel-io/public/bids-client/-/commit/80ee52736b9ff107c00add51a7eee7b999fc0907), but I just realized we needed to update our template with it.